### PR TITLE
add missing relational junctor '!='

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -950,6 +950,7 @@ module.exports = grammar({
       prec.left(1, seq($._expression, '&&', $._expression)),
       // relational
       prec.left(2, seq($._expression, '=', $._expression)),
+      prec.left(2, seq($._expression, '!=', $._expression)),
       prec.left(2, seq($._expression, '<', $._expression)),
       prec.left(2, seq($._expression, '>', $._expression)),
       prec.left(2, seq($._expression, '<=', $._expression)),

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -7,13 +7,13 @@ SELECT ( -?a AS $x ) {}
 ---
 
 (unit
-  (select_query 
-    (select_clause 
+  (select_query
+    (select_clause
       (unary_expression
         (var))
       (var))
     (where_clause
-      (group_graph_pattern)))) 
+      (group_graph_pattern))))
 
 ==================
 Binary expression
@@ -24,14 +24,66 @@ SELECT ( ?a + ?b AS $x ) {}
 ---
 
 (unit
-  (select_query 
-    (select_clause 
+  (select_query
+    (select_clause
       (binary_expression
         (var)
         (var))
       (var))
     (where_clause
       (group_graph_pattern))))
+
+
+==================
+Binary relational expression
+==================
+
+SELECT * {
+  FILTER ( 1 = 2 )
+  FILTER ( 1 != 2 )
+  FILTER ( 1 < 2 )
+  FILTER ( 1 <= 2 )
+  FILTER ( 1 > 2 )
+  FILTER ( 1 >= 2 )
+}
+
+---
+
+(unit
+  (select_query
+    (select_clause)
+    (where_clause
+      (group_graph_pattern
+        (filter
+          (bracketted_expression
+            (binary_expression
+              (integer)
+              (integer))))
+        (filter
+          (bracketted_expression
+            (binary_expression
+              (integer)
+              (integer))))
+        (filter
+          (bracketted_expression
+            (binary_expression
+              (integer)
+              (integer))))
+        (filter
+          (bracketted_expression
+            (binary_expression
+              (integer)
+              (integer))))
+        (filter
+          (bracketted_expression
+            (binary_expression
+              (integer)
+              (integer))))
+        (filter
+          (bracketted_expression
+            (binary_expression
+              (integer)
+              (integer))))))))
 
 ==================
 Precedence levels
@@ -42,8 +94,8 @@ SELECT ( ?a + ?b * 1 AS $x ) {}
 ---
 
 (unit
-  (select_query 
-    (select_clause 
+  (select_query
+    (select_clause
       (binary_expression
         (var)
         (binary_expression
@@ -62,7 +114,7 @@ SELECT ( foo:bar(?a, 1)  AS ?x ) {}
 ---
 
 (unit (select_query
-  (select_clause 
+  (select_clause
     (function_call
       identifier: (prefixed_name
         (namespace (pn_prefix))


### PR DESCRIPTION
Hey, first of all thanks a lot for your awesome work!

I found some issues i'd like to fix.

This PR, adds the missing `!=` junctor in the `binary_expression` rule.
I also added some more tests to catch this error.